### PR TITLE
[#33] Refactoring

### DIFF
--- a/Engine/AIAttackComponent.cpp
+++ b/Engine/AIAttackComponent.cpp
@@ -20,13 +20,12 @@ AIAttackComponent::AIAttackComponent(GameObject* gameObject)
 
 void AIAttackComponent::SetTarget(GameObject* target) {
     if (target) {
-        targetTransform = target->GetComponent<TransformComponent>();
-        if (targetTransform)
-            LOG_INFO("AIAttackComponent target set to " + target->GetName());
-        else
-            LOG_ERROR("AIAttackComponent: target has no TransformComponent.");
+        targetGameObject = target->GetWeakPtr();
+        auto t = targetGameObject.lock();
+        if (t)
+            LOG_INFO("AIAttackComponent target set to " + t->GetName());
     } else {
-        targetTransform = nullptr;
+        targetGameObject.reset();
         LOG_WARN("AIAttackComponent: target cleared.");
     }
 }
@@ -34,7 +33,13 @@ void AIAttackComponent::SetTarget(GameObject* target) {
 void AIAttackComponent::SetAttackRange(float range) { attackRange = range; }
 
 void AIAttackComponent::Update(float) {
-    if (!selfTransform || !targetTransform || !attack) return;
+    if (!selfTransform || !attack) return;
+
+    auto target = targetGameObject.lock();
+    if (!target) return;
+
+    auto* targetTransform = target->GetComponent<TransformComponent>();
+    if (!targetTransform) return;
 
     Vector2Df diff =
         targetTransform->GetWorldPosition() - selfTransform->GetWorldPosition();

--- a/Engine/AIAttackComponent.h
+++ b/Engine/AIAttackComponent.h
@@ -1,10 +1,12 @@
 #pragma once
 #include "Component.h"
 #include "EngineAPI.h"
+#include <memory>
 
 namespace MyEngine {
 class TransformComponent;
 class AttackComponent;
+class GameObject;
 
 class ENGINE_API AIAttackComponent : public Component {
    public:
@@ -18,7 +20,7 @@ class ENGINE_API AIAttackComponent : public Component {
 
    private:
     TransformComponent* selfTransform = nullptr;
-    TransformComponent* targetTransform = nullptr;
+    std::weak_ptr<GameObject> targetGameObject;
     AttackComponent* attack = nullptr;
     float attackRange = 150.f;
 };

--- a/Engine/FollowComponent.cpp
+++ b/Engine/FollowComponent.cpp
@@ -15,7 +15,7 @@ FollowComponent::FollowComponent(GameObject* gameObject)
 }
 
 void FollowComponent::Update(float deltaTime) {
-    if (transform == nullptr || targetTransform == nullptr) {
+    if (transform == nullptr) {
         return;
     }
 
@@ -23,6 +23,12 @@ void FollowComponent::Update(float deltaTime) {
         --skipFrames;
         return;
     }
+
+    auto target = targetGameObject.lock();
+    if (!target) return;
+
+    auto* targetTransform = target->GetComponent<TransformComponent>();
+    if (!targetTransform) return;
 
     Vector2Df currentPos = transform->GetWorldPosition();
     Vector2Df targetPos = targetTransform->GetWorldPosition();
@@ -46,14 +52,15 @@ void FollowComponent::Render() {}
 void FollowComponent::SetTarget(GameObject* targetObject) {
     if (!targetObject) {
         LOG_WARN("FollowComponent: SetTarget called with nullptr.");
-        targetTransform = nullptr;
+        targetGameObject.reset();
         return;
     }
-    targetTransform = targetObject->GetComponent<TransformComponent>();
-    if (targetTransform) {
+    targetGameObject = targetObject->GetWeakPtr();
+    auto locked = targetGameObject.lock();
+    if (locked) {
         LOG_INFO("FollowComponent: target set to " + targetObject->GetName());
     } else {
-        LOG_ERROR("FollowComponent: target object has no TransformComponent.");
+        LOG_ERROR("FollowComponent: failed to lock target weak_ptr.");
     }
 }
 

--- a/Engine/FollowComponent.h
+++ b/Engine/FollowComponent.h
@@ -3,6 +3,7 @@
 #include "TransformComponent.h"
 #include "SpriteRendererComponent.h"
 #include "EngineAPI.h"
+#include <memory>
 
 namespace MyEngine {
 class ENGINE_API FollowComponent : public Component {
@@ -19,7 +20,7 @@ class ENGINE_API FollowComponent : public Component {
 
    private:
     TransformComponent* transform = nullptr;
-    TransformComponent* targetTransform = nullptr;
+    std::weak_ptr<GameObject> targetGameObject;
     SpriteRendererComponent* spriteRenderer = nullptr;
 
     float speed = 100.f;

--- a/Engine/GameObject.h
+++ b/Engine/GameObject.h
@@ -1,12 +1,13 @@
 #pragma once
 #include "TransformComponent.h"
 #include <iostream>
+#include <memory>
 #include "EngineAPI.h"
 
 namespace MyEngine {
 class TransformComponent;
 
-class ENGINE_API GameObject {
+class ENGINE_API GameObject : public std::enable_shared_from_this<GameObject> {
    public:
     GameObject();
     GameObject(std::string newName);
@@ -17,6 +18,8 @@ class ENGINE_API GameObject {
 
     void Update(float deltaTime);
     void Render();
+
+    std::weak_ptr<GameObject> GetWeakPtr() { return weak_from_this(); }
 
     template <typename T>
     T* AddComponent() {

--- a/Engine/GameWorld.cpp
+++ b/Engine/GameWorld.cpp
@@ -1,6 +1,8 @@
 #include "pch.h"
 #include "GameWorld.h"
 #include "Logger.h"
+#include <algorithm>
+#include <unordered_set>
 
 namespace MyEngine {
 GameWorld* GameWorld::Instance() {
@@ -9,8 +11,8 @@ GameWorld* GameWorld::Instance() {
 }
 
 void GameWorld::Update(float deltaTime) {
-    for (int i = 0; i < gameObjects.size(); i++) {
-        gameObjects[i]->Update(deltaTime);
+    for (auto& gObj : gameObjects) {
+        gObj->Update(deltaTime);
     }
 }
 
@@ -23,66 +25,85 @@ void GameWorld::FixedUpdate(float deltaTime) {
 }
 
 void GameWorld::Render() {
-    for (int i = 0; i < gameObjects.size(); i++) {
-        gameObjects[i]->Render();
+    for (auto& gObj : gameObjects) {
+        gObj->Render();
     }
 }
 
 void GameWorld::LateUpdate() {
-    // Standard deferred removals
-    for (int i = (int)markedToDestroyGameObjects.size() - 1; i >= 0; i--) {
-        DestroyGameObjectImmediate(markedToDestroyGameObjects[i]);
-    }
-    // Automatic removal of empty particle emitters
-    for (int i = (int)gameObjects.size() - 1; i >= 0; i--) {
-        GameObject* gObj = gameObjects[i];
-        // Check to see if it has already been marked for deletion
-        if (std::find(markedToDestroyGameObjects.begin(),
-                      markedToDestroyGameObjects.end(),
-                      gObj) != markedToDestroyGameObjects.end())
-            continue;
+    // --- Безопасное удаление помеченных объектов ---
+    // Берём копию, чтобы избежать модификации вектора во время итерации
+    std::vector<GameObject*> toDestroy = markedToDestroyGameObjects;
+    markedToDestroyGameObjects.clear();
 
+    for (GameObject* go : toDestroy) {
+        // Проверяем, жив ли ещё объект (мог быть уже удалён как потомок
+        // другого)
+        auto it = std::find_if(gameObjects.begin(), gameObjects.end(),
+                               [go](const std::shared_ptr<GameObject>& sp) {
+                                   return sp.get() == go;
+                               });
+        if (it != gameObjects.end()) {
+            DestroyGameObjectImmediate(go);
+        }
+        // Если объект уже отсутствует, просто пропускаем
+    }
+
+    // --- Автоудаление по истечению срока (IsExpired) ---
+    for (int i = (int)gameObjects.size() - 1; i >= 0; --i) {
+        auto& go = gameObjects[i];
         bool expired = false;
-        for (const auto* comp : gObj->GetAllComponents()) {
+        for (const auto* comp : go->GetAllComponents()) {
             if (comp->IsExpired()) {
                 expired = true;
                 break;
             }
         }
         if (expired) {
-            DestroyGameObject(gObj);    // delayed deletion on the next frame
+            DestroyGameObject(go.get());  // будет удалён на следующем кадре
         }
     }
 }
 
 GameObject* GameWorld::CreateGameObject() {
-    GameObject* newGameObject = new GameObject();
-    gameObjects.push_back(newGameObject);
-    return newGameObject;
+    auto gObject =  std::make_shared<GameObject>();
+    gameObjects.push_back(gObject);
+    return gObject.get();
 }
 
 GameObject* GameWorld::CreateGameObject(std::string name) {
-    GameObject* newGameObject = new GameObject(name);
-    gameObjects.push_back(newGameObject);
-    return newGameObject;
+    auto gObject = std::make_shared<GameObject>(name);
+    gameObjects.push_back(gObject);
+    return gObject.get();
 }
 
 void GameWorld::DestroyGameObject(GameObject* gameObject) {
-    markedToDestroyGameObjects.push_back(gameObject);
+    // Перестраховка: если объекта нет в хранилище – выходим
+    auto it = std::find_if(gameObjects.begin(), gameObjects.end(),
+                           [gameObject](const std::shared_ptr<GameObject>& sp) {
+                               return sp.get() == gameObject;
+                           });
+    if (it == gameObjects.end()) return;
+
+    // Проверка, что не помечен уже
+    if (std::find(markedToDestroyGameObjects.begin(),
+                  markedToDestroyGameObjects.end(),
+                  gameObject) == markedToDestroyGameObjects.end()) {
+        markedToDestroyGameObjects.push_back(gameObject);
+    }
 }
 
 void GameWorld::Clear() {
-    for (int i = (int)gameObjects.size() - 1; i >= 0; i--) {
-        if (gameObjects[i] == nullptr) {
-            continue;
-        }
-
-        if (gameObjects[i]->GetComponent<TransformComponent>()->GetParent() ==
-            nullptr) {
-            DestroyGameObjectImmediate(gameObjects[i]);
+    // Сначала сбросим родительские связи, чтобы деструкторы не пытались удалить
+    // детей повторно
+    for (auto& go : gameObjects) {
+        auto* transform = go->GetComponent<TransformComponent>();
+        if (transform && transform->GetParent()) {
+            transform->SetParent(nullptr);
         }
     }
-
+    gameObjects.clear();
+    markedToDestroyGameObjects.clear();
     fixedCounter = 0.f;
 }
 
@@ -97,48 +118,89 @@ void GameWorld::Print() const {
     }
 }
 
+std::vector<GameObject*> GameWorld::GetAllGameObjects() const {
+    std::vector<GameObject*> raw;
+    raw.reserve(gameObjects.size());
+    for (const auto& go : gameObjects) {
+        raw.push_back(go.get());
+    }
+    return raw;
+}
+
 void GameWorld::BringToFront(GameObject* obj) { 
-    auto it = std::find(gameObjects.begin(), gameObjects.end(), obj);
+    auto it = std::find_if(
+        gameObjects.begin(), gameObjects.end(),
+        [obj](const std::shared_ptr<GameObject>& p) { return p.get() == obj; });
     if (it != gameObjects.end()) {
+        auto sp = *it;
         gameObjects.erase(it);
-        gameObjects.push_back(obj);
+        gameObjects.push_back(sp);
     }
 }
 
 void GameWorld::InsertBefore(GameObject* obj, GameObject* beforeThis) {
     auto itBefore =
-        std::find(gameObjects.begin(), gameObjects.end(), beforeThis);
-    auto itObj = std::find(gameObjects.begin(), gameObjects.end(), obj);
+        std::find_if(gameObjects.begin(), gameObjects.end(),
+                  [beforeThis](const std::shared_ptr<GameObject>& p) {
+                      return p.get() == beforeThis;
+                  });
+    auto itObj = std::find_if(
+        gameObjects.begin(), gameObjects.end(),
+        [obj](const std::shared_ptr<GameObject>& p) { return p.get() == obj; });
     if (itBefore != gameObjects.end() && itObj != gameObjects.end()) {
+        auto sp = *itObj;
         gameObjects.erase(itObj);
-        gameObjects.insert(itBefore, obj);
+        gameObjects.insert(itBefore, sp);
     }
 }
 
 void GameWorld::DestroyGameObjectImmediate(GameObject* gameObject) {
-    auto parent = gameObject->GetComponent<TransformComponent>()->GetParent();
-    if (parent != nullptr) {
-        parent->GetGameObject()->RemoveChild(gameObject);
+    if (!gameObject) return;
+
+    // Проверяем, существует ли объект в главном хранилище
+    auto itRoot =
+        std::find_if(gameObjects.begin(), gameObjects.end(),
+                     [gameObject](const std::shared_ptr<GameObject>& sp) {
+                         return sp.get() == gameObject;
+                     });
+    if (itRoot == gameObjects.end()) return;
+
+    // Собираем множество удаляемых (корень + потомки)
+    std::unordered_set<GameObject*> toRemoveSet;
+    toRemoveSet.insert(gameObject);
+
+    auto* rootTransform = gameObject->GetComponent<TransformComponent>();
+    if (rootTransform) {
+        for (auto& go : gameObjects) {
+            if (go.get() == gameObject) continue;
+            auto* tf = go->GetComponent<TransformComponent>();
+            if (!tf) continue;
+            auto* parent = tf->GetParent();
+            while (parent) {
+                if (parent == rootTransform) {
+                    toRemoveSet.insert(go.get());
+                    break;
+                }
+                parent = parent->GetParent();
+            }
+        }
     }
 
-    for (auto transform :
-         gameObject->GetComponentsInChildren<TransformComponent>()) {
-        GameObject* gameObjectToDelete = transform->GetGameObject();
-
-        gameObjects.erase(std::remove_if(gameObjects.begin(), gameObjects.end(),
-                                         [gameObjectToDelete](GameObject* obj) {
-                                             return obj == gameObjectToDelete;
-                                         }),
-                          gameObjects.end());
-        markedToDestroyGameObjects.erase(
-            std::remove_if(markedToDestroyGameObjects.begin(),
-                           markedToDestroyGameObjects.end(),
-                           [gameObjectToDelete](GameObject* obj) {
-                               return obj == gameObjectToDelete;
-                           }),
-            markedToDestroyGameObjects.end());
-        LOG_INFO("Enemy died. Remaining: " + gameObjectToDelete->GetName());
-        delete gameObjectToDelete;
+    // Отсоединяем от родителя (если есть)
+    if (rootTransform) {
+        auto* parent = rootTransform->GetParent();
+        if (parent) {
+            parent->GetGameObject()->RemoveChild(gameObject);
+        }
     }
+
+    // Удаляем из gameObjects все объекты из множества
+    gameObjects.erase(
+        std::remove_if(gameObjects.begin(), gameObjects.end(),
+                       [&](const std::shared_ptr<GameObject>& sp) {
+                           return toRemoveSet.find(sp.get()) !=
+                                  toRemoveSet.end();
+                       }),
+        gameObjects.end());
 }
 }  // namespace MyEngine

--- a/Engine/GameWorld.h
+++ b/Engine/GameWorld.h
@@ -20,9 +20,9 @@ class ENGINE_API GameWorld {
 
     void Print() const;
 
-    const std::vector<GameObject*>& GetAllGameObjects() const {
-        return gameObjects;
-    }
+    // Returns a list of raw pointers, as before,
+    // but now the owners are shared_ptrs.
+    std::vector<GameObject*> GetAllGameObjects() const;
 
     void BringToFront(GameObject* obj);
 
@@ -37,8 +37,9 @@ class ENGINE_API GameWorld {
 
     float fixedCounter = 0.f;
 
-    std::vector<GameObject*> gameObjects = {};
-    std::vector<GameObject*> markedToDestroyGameObjects = {};
+    // Now GameWorld owns the objects via shared_ptr
+    std::vector<std::shared_ptr<GameObject>> gameObjects;
+    std::vector<GameObject*> markedToDestroyGameObjects;
 
     void DestroyGameObjectImmediate(GameObject* gameObject);
 };

--- a/RogaliqueGame/BossAIComponent.cpp
+++ b/RogaliqueGame/BossAIComponent.cpp
@@ -14,12 +14,11 @@ namespace RogaliqueGame {
 
 BossAIComponent::BossAIComponent(MyEngine::GameObject* gameObject,
                                  MyEngine::GameObject* player)
-    : Component(gameObject), player(player), rng(std::random_device{}()) {
+    : Component(gameObject), m_player(player->GetWeakPtr()), rng(std::random_device{}()) {
     transform = gameObject->GetComponent<MyEngine::TransformComponent>();
     rigidbody = gameObject->GetComponent<MyEngine::RigidbodyComponent>();
     health = gameObject->GetComponent<MyEngine::HealthComponent>();
     attackComp = gameObject->GetComponent<MyEngine::AttackComponent>();
-    playerTransform = player->GetComponent<MyEngine::TransformComponent>();
     spriteRenderer =
         gameObject->GetComponent<MyEngine::SpriteRendererComponent>();
 }
@@ -35,6 +34,14 @@ void BossAIComponent::Update(float deltaTime) {
         SetState(DEAD);
         return;
     }
+
+    auto player = m_player.lock();
+    if (!player) {
+        return;
+    }
+
+    auto playerTransform = player->GetComponent<MyEngine::TransformComponent>();
+    if (!playerTransform) return;
 
     // Sprite facing the player (always)
     if (spriteRenderer && playerTransform) {
@@ -72,6 +79,11 @@ void BossAIComponent::UpdateIdle(float dt) {
 }
 
 void BossAIComponent::UpdateChasing(float dt) {
+    auto player = m_player.lock();
+    if (!player) {
+        return;
+    }
+    auto playerTransform = player->GetComponent<MyEngine::TransformComponent>();
     if (!playerTransform) return;
 
     MyEngine::Vector2Df myPos = transform->GetWorldPosition();
@@ -112,6 +124,12 @@ void BossAIComponent::UpdateChasing(float dt) {
 }
 
 void BossAIComponent::UpdateAttackCharge(float dt) {
+    auto player = m_player.lock();
+    if (!player) {
+        return;
+    }
+    auto playerTransform = player->GetComponent<MyEngine::TransformComponent>();
+    if (!playerTransform) return;
     stateTimer += dt;
     // Moving in the same direction
     transform->MoveBy(chargeDirection * chargeSpeed * dt);
@@ -164,6 +182,12 @@ void BossAIComponent::UpdateAttackShockwave(float dt) {
 }
 
 void BossAIComponent::UpdateAttackTeleport(float dt) {
+    auto player = m_player.lock();
+    if (!player) {
+        return;
+    }
+    auto playerTransform = player->GetComponent<MyEngine::TransformComponent>();
+    if (!playerTransform) return;
     // Instant execution on entry
     if (stateTimer == 0.0f) {
         // Teleport to a random location near the player
@@ -188,6 +212,12 @@ void BossAIComponent::UpdateAttackTeleport(float dt) {
 }
 
 void BossAIComponent::ExecuteCharge() {
+    auto player = m_player.lock();
+    if (!player) {
+        return;
+    }
+    auto playerTransform = player->GetComponent<MyEngine::TransformComponent>();
+    if (!playerTransform) return;
     // keep the player in our sights
     MyEngine::Vector2Df dir =
         playerTransform->GetWorldPosition() - transform->GetWorldPosition();

--- a/RogaliqueGame/BossAIComponent.h
+++ b/RogaliqueGame/BossAIComponent.h
@@ -2,6 +2,7 @@
 #include "Component.h"
 #include "Vector.h"
 #include <random>
+#include <memory>
 
 namespace MyEngine {
 class GameObject;
@@ -42,9 +43,8 @@ class BossAIComponent : public MyEngine::Component {
     void ExecuteShockwave();
     void ExecuteTeleport();
 
-    MyEngine::GameObject* player;
+    std::weak_ptr<MyEngine::GameObject> m_player;
     MyEngine::TransformComponent* transform;
-    MyEngine::TransformComponent* playerTransform;
     MyEngine::RigidbodyComponent* rigidbody;
     MyEngine::HealthComponent* health;
     MyEngine::AttackComponent* attackComp;


### PR DESCRIPTION
GameWorld now holds objects via a std::vector<std::shared_ptr<GameObject>>.

GameObject inherits std::enable_shared_from_this, providing weak_ptrs to observers.

AIAttackComponent, FollowComponent, and BossAIComponent store targets as std::weak_ptr<GameObject>, checking their viability before dereferencing.

LateUpdate and DestroyGameObjectImmediate are fully protected against double deletion and iterator invalidation.


GameWorld теперь владеет объектами через std::vector<std::shared_ptr<GameObject>>.

GameObject наследует std::enable_shared_from_this, предоставляя weak_ptr наблюдателям.

AIAttackComponent, FollowComponent, BossAIComponent хранят цели как std::weak_ptr<GameObject>, проверяя их жизнеспособность перед разыменованием.

LateUpdate и DestroyGameObjectImmediate полностью защищены от повторного удаления и инвалидации итераторов.



